### PR TITLE
Update echopype conda package to v0.5.0.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,29 +9,43 @@ source:
   sha256: f7a2616b54d4b367d729c9b22a77874aabe8f6f286685cbe1f70fb8fa856f50f
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script:
+    - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}    # [unix]
+    - set SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}    # [win]
+    - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
   host:
     - pip
-    - python
+    - python >=3.6
+    - setuptools >=45
   run:
-    - python
+    - python >=3.6
     - matplotlib-base
-    - netCDF4
+    - dask
+    - netCDF4 ==1.5.5
     - numpy
     - pandas
     - pynmea2
     - pytz
     - scipy
-    - xarray
+    - xarray ==0.16.2
     - zarr
+    - fsspec ==0.8.7
+    - s3fs ==0.5.2
+    - requests
+    - aiohttp
 
 test:
   imports:
     - echopype
+  commands:
+    - pip check
+    - python -c "import echopype; assert echopype.__version__ != '0.0.0'"
+  requires:
+    - pip
 
 about:
   home: https://github.com/OSOceanAcoustics/echopype


### PR DESCRIPTION
This PR updates echopype conda package to v0.5.0.

## Status
05/10/2021 Updated recipe to get ready for using setuptools_scm. Echopype v0.5.0 has not been release yet. **DO NOT MERGE THIS PR**.